### PR TITLE
pass in other activity results that may not belong to jumio

### DIFF
--- a/android/src/main/java/com/jumio/react/JumioActivity.java
+++ b/android/src/main/java/com/jumio/react/JumioActivity.java
@@ -52,6 +52,8 @@ public class JumioActivity extends ReactActivity {
 				startSdk(JumioModuleNetverify.netverifySDK);
 			} else if (requestCode == JumioModuleDocumentVerification.PERMISSION_REQUEST_CODE_DOCUMENT_VERIFICATION) {
 				startSdk(JumioModuleDocumentVerification.documentVerificationSDK);
+			}	else {
+				super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 			}
 		} else {
 			Toast.makeText(this, "You need to grant all required permissions to start the Jumio SDK", Toast.LENGTH_LONG).show();

--- a/android/src/main/java/com/jumio/react/JumioActivity.java
+++ b/android/src/main/java/com/jumio/react/JumioActivity.java
@@ -226,6 +226,8 @@ public class JumioActivity extends ReactActivity {
 				int errorCode = data.getIntExtra(DocumentVerificationSDK.EXTRA_ERROR_CODE, 0);
 				String errorMsg = data.getStringExtra(DocumentVerificationSDK.EXTRA_ERROR_MESSAGE);
 				sendErrorObject(errorCode, errorMsg, scanReference);
+			}	else {
+	      this.getReactInstanceManager().onActivityResult(this, requestCode, resultCode, data);
 			}
 		}
 	}
@@ -260,4 +262,3 @@ public class JumioActivity extends ReactActivity {
 		sendEvent(this.getReactInstanceManager().getCurrentReactContext(), "EventError", errorResult);
 	}
 }
-

--- a/android/src/main/java/com/jumio/react/JumioActivity.java
+++ b/android/src/main/java/com/jumio/react/JumioActivity.java
@@ -63,6 +63,7 @@ public class JumioActivity extends ReactActivity {
 
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
 		if (requestCode == BamSDK.REQUEST_CODE) {
 			if (data == null) {
 				return;


### PR DESCRIPTION
Because of how `onActivityResults` is setup for jumio it doesn't pass in other results, so other modules may sometimes not work. Example: `react-native-image-picker` the image results get sent to jumio's `onAcitivityResults`, but isn't passed correctly to the activity. The PR here is to fix that issue. relates to https://github.com/react-community/react-native-image-picker/issues/673