### PR TITLE
Pass other results

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,22 @@ repositories {
 }
 ```
 
-5. Change the extend of your MainActivity to JumioActivity
+5. Change the extend of your MainActivity to JumioActivity. Also add `jumioOnActivityResult` to your `onActivityResult` method
 ```
 import com.jumio.react.JumioActivity;
 
 public class MainActivity extends JumioActivity {
+  /* other code */
+
+	@Override
+	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
+    jumioOnActivityResult(requestCode, resultCode, data);
+    /* other onActivityResult code */
+  }
+
+  /* other code */
+}
 ```
 
 ## Usage

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
 }
 
 ext {
@@ -18,31 +18,31 @@ repositories {
 
 
 dependencies {
-    implementation "com.jumio.android:core:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:bam:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:nv:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:nv-mrz:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:nv-nfc:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:nv-ocr:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:nv-barcode:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:nv-barcode-vision:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:nv-liveness:${SDK_VERSION}@aar"
-    implementation "com.jumio.android:dv:${SDK_VERSION}@aar"
+    compile "com.jumio.android:core:${SDK_VERSION}@aar"
+    compile "com.jumio.android:bam:${SDK_VERSION}@aar"
+    compile "com.jumio.android:nv:${SDK_VERSION}@aar"
+    compile "com.jumio.android:nv-mrz:${SDK_VERSION}@aar"
+    compile "com.jumio.android:nv-nfc:${SDK_VERSION}@aar"
+    compile "com.jumio.android:nv-ocr:${SDK_VERSION}@aar"
+    compile "com.jumio.android:nv-barcode:${SDK_VERSION}@aar"
+    compile "com.jumio.android:nv-barcode-vision:${SDK_VERSION}@aar"
+    compile "com.jumio.android:nv-liveness:${SDK_VERSION}@aar"
+    compile "com.jumio.android:dv:${SDK_VERSION}@aar"
 
     //for core:
-    implementation "com.android.support:support-v4:27.0.2"
-    api "com.android.support:appcompat-v7:27.0.2"
+    compile "com.android.support:support-v4:26.1.0"
+    compile "com.android.support:appcompat-v7:26.1.0"
 
     //for nv:
-    implementation "com.android.support:design:27.0.2"
-    implementation "com.android.support:cardview-v7:27.0.2"
+    compile "com.android.support:design:26.1.0"
+    compile "com.android.support:cardview-v7:26.1.0"
 
     //only for nv-nfc
-    implementation "com.madgag.spongycastle:prov:1.58.0.0"
-    implementation "net.sf.scuba:scuba-sc-android:0.0.13"
+    compile "com.madgag.spongycastle:prov:1.58.0.0"
+    compile "net.sf.scuba:scuba-sc-android:0.0.12"
 
     //only for nv-barcode-vision
-    implementation "com.google.android.gms:play-services-vision:11.8.0"
+    compile "com.google.android.gms:play-services-vision:11.4.0"
 
-    implementation 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,14 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.jumio.react">
-    
+
     <uses-sdk
-    android:minSdkVersion="19"
-    android:targetSdkVersion="27" />
-    
+    android:minSdkVersion="16"
+    android:targetSdkVersion="22" />
+
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
-    
+
     <application>
         <meta-data
             android:name="com.google.android.gms.vision.DEPENDENCIES"
@@ -31,17 +31,17 @@
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:hardwareAccelerated="true"
             android:theme="@style/Theme.DocumentVerification"/>
-            
+
         -keep class net.sf.scuba.smartcards.IsoDepCardService {*;}
         -keep class org.jmrtd.** { *; }
         -keep class net.sf.scuba.** {*;}
         -keep class org.spongycastle.** {*;}
         -keep class org.ejbca.** {*;}
-        
+
         -dontwarn java.nio.**
         -dontwarn org.codehaus.**
         -dontwarn org.ejbca.**
         -dontwarn org.spongycastle.**
     </application>
-    
+
 </manifest>

--- a/android/src/main/java/com/jumio/react/JumioActivity.java
+++ b/android/src/main/java/com/jumio/react/JumioActivity.java
@@ -32,8 +32,19 @@ import com.jumio.nv.enums.NVGender;
 
 import java.util.ArrayList;
 import java.util.Locale;
+import com.facebook.CallbackManager;
 
 public class JumioActivity extends ReactActivity {
+
+  private static CallbackManager mCallbackManager = null;
+
+	protected static CallbackManager setCallbackManager(CallbackManager callbackManager) {
+		mCallbackManager = mCallbackManager;
+	}
+
+  protected static CallbackManager getCallbackManager() {
+    return mCallbackManager;
+  }
 
 	@Override
 	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
@@ -52,6 +63,8 @@ public class JumioActivity extends ReactActivity {
 				startSdk(JumioModuleNetverify.netverifySDK);
 			} else if (requestCode == JumioModuleDocumentVerification.PERMISSION_REQUEST_CODE_DOCUMENT_VERIFICATION) {
 				startSdk(JumioModuleDocumentVerification.documentVerificationSDK);
+			}	else {
+				super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 			}
 		} else {
 			Toast.makeText(this, "You need to grant all required permissions to start the Jumio SDK", Toast.LENGTH_LONG).show();
@@ -61,6 +74,7 @@ public class JumioActivity extends ReactActivity {
 
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
 		if (requestCode == BamSDK.REQUEST_CODE) {
 			if (data == null) {
 				return;
@@ -226,8 +240,11 @@ public class JumioActivity extends ReactActivity {
 				int errorCode = data.getIntExtra(DocumentVerificationSDK.EXTRA_ERROR_CODE, 0);
 				String errorMsg = data.getStringExtra(DocumentVerificationSDK.EXTRA_ERROR_MESSAGE);
 				sendErrorObject(errorCode, errorMsg, scanReference);
+			}	else {
+	      this.getReactInstanceManager().onActivityResult(this, requestCode, resultCode, data);
 			}
 		}
+		if (mCallbackManager !== null) mCallbackManager.onActivityResult(requestCode, resultCode, data);
 	}
 
 	// Helper methods
@@ -260,4 +277,3 @@ public class JumioActivity extends ReactActivity {
 		sendEvent(this.getReactInstanceManager().getCurrentReactContext(), "EventError", errorResult);
 	}
 }
-

--- a/android/src/main/java/com/jumio/react/JumioActivity.java
+++ b/android/src/main/java/com/jumio/react/JumioActivity.java
@@ -32,19 +32,8 @@ import com.jumio.nv.enums.NVGender;
 
 import java.util.ArrayList;
 import java.util.Locale;
-import com.facebook.CallbackManager;
 
 public class JumioActivity extends ReactActivity {
-
-  private static CallbackManager mCallbackManager = null;
-
-	protected static CallbackManager setCallbackManager(CallbackManager callbackManager) {
-		mCallbackManager = mCallbackManager;
-	}
-
-  protected static CallbackManager getCallbackManager() {
-    return mCallbackManager;
-  }
 
 	@Override
 	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
@@ -72,9 +61,7 @@ public class JumioActivity extends ReactActivity {
 		}
 	}
 
-	@Override
-	public void onActivityResult(int requestCode, int resultCode, Intent data) {
-		super.onActivityResult(requestCode, resultCode, data);
+	protected void jumioOnActivityResult(int requestCode, int resultCode, Intent data) {
 		if (requestCode == BamSDK.REQUEST_CODE) {
 			if (data == null) {
 				return;
@@ -244,7 +231,6 @@ public class JumioActivity extends ReactActivity {
 	      this.getReactInstanceManager().onActivityResult(this, requestCode, resultCode, data);
 			}
 		}
-		if (mCallbackManager !== null) mCallbackManager.onActivityResult(requestCode, resultCode, data);
 	}
 
 	// Helper methods

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react-native": ">=0.47.1",
-    "react-native-fbsdk": "git+https://github.com/QuartermasterInc/react-native-fbsdk.git#d2be3df7adc4147209f9f766de313b96bc0d07e4"
+    "react-native": ">=0.47.1"
   },
   "author": "Jumio Corporation",
   "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react-native": ">=0.47.1"
+    "react-native": ">=0.47.1",
+    "react-native-fbsdk": "git+https://github.com/QuartermasterInc/react-native-fbsdk.git#d2be3df7adc4147209f9f766de313b96bc0d07e4"
   },
   "author": "Jumio Corporation",
   "license": "ISC"


### PR DESCRIPTION
I have come to an issue with the SDK where it was overriding other third-party SDKs onActivityResult callback, including [`react-native-fbsdk`](https://github.com/facebook/react-native-fbsdk) and [`react-native-image-picker`](https://github.com/react-community/react-native-image-picker). I've changed the onActivityResult here to be passed in as a parent method into the child activity. This will allow the child to override onActivityResult in its own Activity and also add other third-party methods that require to be called at this time.

I've also updated the docs.
