### PR TITLE
Remove react as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "author": "Jumio Corporation",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "react-native": "^0.55.2"
   }
 }


### PR DESCRIPTION
Having React-Native as dependecy in the module create conflicts with the metro bundler : 
```
Loading dependency graph...(node:13980) UnhandledPromiseRejectionWarning: Error: jest-haste-map: @providesModule naming collision:
  Duplicate module name: react-animated
  Paths: .../node_modules/react-native/Libraries/Animated/release/package.json collides with .../node_modules/react-native-jumio-mobilesdk/node_modules/react-native/Libraries/Animated/release/package.json
```

External dependencies should use `peerDependencies` and eventually `devDependencies`