### PR TITLE
Xcode 12 compatibility

### DIFF
--- a/react-native-jumio-mobilesdk.podspec
+++ b/react-native-jumio-mobilesdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,c,m,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "JumioMobileSDK", "3.7.1"
 end
 


### PR DESCRIPTION
Hi Jumio team!

I know that this github repository isn't your main avenue for support/changes, but I still wanted to open this here.
The Xcode 12 build system was updated, causing issues with all `s.dependency 'React'` statements. Apparently "React-Core" was always the "real" dependency, but some build system behavior that was being relied on was changed.

All react-native iOS libraries are being updated with this change.

Info here: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116