### PR TITLE
fix: react-native 0.63.4 compatibility 

### DIFF
--- a/DemoApp/ios/Podfile
+++ b/DemoApp/ios/Podfile
@@ -1,40 +1,14 @@
 platform :ios, '10.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+
 
 #source 'https://github.com/CocoaPods/Specs.git'
 
 def pods()
   # Pods for RnDiffApp
-  pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "../node_modules/react-native/Libraries/TypeSafety"
-  pod 'React', :path => '../node_modules/react-native/'
-  pod 'React-Core', :path => '../node_modules/react-native/'
-  pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-  pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-  pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-  pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-  pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-  pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-  pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-  pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
-  pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-  pod 'React-callinvoker', :path => "../node_modules/react-native/ReactCommon/callinvoker"
-  pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
-  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-  
-  use_native_modules!
+  config = use_native_modules!
+  use_react_native!(:path => config["reactNativePath"])
   use_frameworks!
 end
 

--- a/DemoApp/ios/Podfile.lock
+++ b/DemoApp/ios/Podfile.lock
@@ -191,9 +191,9 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-jumio-mobilesdk (3.9.0):
+  - react-native-jumio-mobilesdk (3.9.1):
     - JumioMobileSDK (= 3.9.0)
-    - React
+    - React-Core
   - React-RCTActionSheet (0.63.4):
     - React-Core/RCTActionSheetHeaders (= 0.63.4)
   - React-RCTAnimation (0.63.4):
@@ -277,7 +277,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
-  - react-native-jumio-mobilesdk (from `../..`)
+  - react-native-jumio-mobilesdk (from `../node_modules/react-native-jumio-mobilesdk`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -330,7 +330,7 @@ EXTERNAL SOURCES:
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-jumio-mobilesdk:
-    :path: "../.."
+    :path: "../node_modules/react-native-jumio-mobilesdk"
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -373,7 +373,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-jumio-mobilesdk: e207ffed54215f3b52bd280d7bcca9cce27e51a3
+  react-native-jumio-mobilesdk: cc87eedfe9f0bcf1403394758f71d28c38974341
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0
@@ -388,6 +388,6 @@ SPEC CHECKSUMS:
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
-PODFILE CHECKSUM: 5acd3d075d595f23d5a9158deb761b074e386401
+PODFILE CHECKSUM: 4df6cc3f8c60342af0c749caad9a76b8cfd66f7f
 
 COCOAPODS: 1.10.1

--- a/DemoApp/package-lock.json
+++ b/DemoApp/package-lock.json
@@ -25,6 +25,7 @@
       }
     },
     "..": {
+      "name": "react-native-jumio-mobilesdk",
       "version": "3.9.1",
       "license": "SEE LICENSE IN README.md",
       "peerDependencies": {

--- a/react-native-jumio-mobilesdk.podspec
+++ b/react-native-jumio-mobilesdk.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,c,m,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "JumioMobileSDK", "3.9.0"
 end


### PR DESCRIPTION
I here, 

On "Aumaxpourmoi" application, we are using Jumio bridge for react-native. 
This pull request bring (back?) the compatibility with react-native 0.63.4.

I found in the project history [this commit](https://github.com/Jumio/mobile-react/commit/ee944a9207394425b14c72b70e14a8803827af33) who bring this compatibility. 
This modification is then erase by [this merge](https://github.com/Jumio/mobile-react/commit/ad1b1cfadc21fa31d0230d1daf30520bf07cd069). I suppose a conflict resolution error. 
I think some simple github actions could prevent this error from happening. A quick search led me [here for an Android build](https://github.com/marketplace/actions/android-build) and [here for an iOS build](https://github.com/marketplace/actions/ios-build-action)

The second commit complete the demo app upgrade to RN 0.63, and update the different lock files. 

Thanks for your attention,

Linked PR : https://github.com/Jumio/mobile-react/pull/17