### PR TITLE
[iOS] Use current viewcontroller to present sdk views

### DIFF
--- a/ios/JumioMobileSDKBamCheckout.m
+++ b/ios/JumioMobileSDKBamCheckout.m
@@ -5,6 +5,8 @@
 //
 
 #import "JumioMobileSDKBamCheckout.h"
+#import <React/RCTUtils.h>
+
 @import JumioCore;
 @import BAMCheckout;
 
@@ -163,8 +165,8 @@ RCT_EXPORT_METHOD(startBAM) {
     }
     
     dispatch_sync(dispatch_get_main_queue(), ^{
-        id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
-        [delegate.window.rootViewController presentViewController: _bamViewController animated: YES completion: nil];
+        UIViewController *presentedViewController = RCTPresentedViewController();
+        [presentedViewController presentViewController: _bamViewController animated: YES completion: nil];
     });
 }
 

--- a/ios/JumioMobileSDKDocumentVerification.m
+++ b/ios/JumioMobileSDKDocumentVerification.m
@@ -5,6 +5,7 @@
 //
 
 #import "JumioMobileSDKDocumentVerification.h"
+#import <React/RCTUtils.h>
 
 @import JumioCore;
 @import DocumentVerification;
@@ -130,8 +131,8 @@ RCT_EXPORT_METHOD(startDocumentVerification) {
     }
     
     dispatch_sync(dispatch_get_main_queue(), ^{
-        id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
-        [delegate.window.rootViewController presentViewController: self.documentVerificationViewController animated: YES completion: nil];
+        UIViewController *presentedViewController = RCTPresentedViewController();
+        [presentedViewController presentViewController: self.documentVerificationViewController animated: YES completion: nil];
     });
 }
 

--- a/ios/JumioMobileSDKNetverify.m
+++ b/ios/JumioMobileSDKNetverify.m
@@ -5,6 +5,7 @@
 //
 
 #import "JumioMobileSDKNetverify.h"
+#import <React/RCTUtils.h>
 
 @import JumioCore;
 @import Netverify;
@@ -252,8 +253,8 @@ RCT_EXPORT_METHOD(startNetverify) {
             NSLog(@"The Netverify SDK is not initialized yet. Call initNetverify() first.");
             return;
         }
-        id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
-        [delegate.window.rootViewController presentViewController: _netverifyViewController animated:YES completion: nil];
+        UIViewController *presentedViewController = RCTPresentedViewController();
+        [presentedViewController presentViewController: _netverifyViewController animated:YES completion: nil];
     });
 }
 


### PR DESCRIPTION
Hi Jumio

Thanks for supporting React Native and providing a great sdk.

I have a very simple change request for iOS.

Rather than presenting the Jumio view controllers from the root controller, can we please instead present Jumio view controllers from the currently presented/visible view controller?

Currently, the Jumio sdk fails to present screens in some apps with complicated nested screen logic or modals.